### PR TITLE
Remove client field from all observers.

### DIFF
--- a/exch_clients/src/huobi_client.rs
+++ b/exch_clients/src/huobi_client.rs
@@ -1,4 +1,4 @@
-use base64::{Engine as _, engine::general_purpose};
+use base64::{engine::general_purpose, Engine as _};
 use chrono::Utc;
 use exch_observer_types::{
     exchanges::huobi::{

--- a/exch_observer_types/src/types.rs
+++ b/exch_observer_types/src/types.rs
@@ -163,7 +163,6 @@ impl Into<String> for &ArbitrageExchangeSymbol {
 impl From<BSymbol> for ArbitrageExchangeSymbol {
     /// Converts a Binance symbol into an ArbitrageExchangeSymbol
     fn from(symbol: BSymbol) -> Self {
-
         let mut base_asset = symbol.base_asset;
         let mut quote_asset = symbol.quote_asset;
         // Convert symbols to lowercase

--- a/exch_subobservers/src/binance_obs.rs
+++ b/exch_subobservers/src/binance_obs.rs
@@ -11,13 +11,12 @@ use std::{
     hash::Hash,
     ops::Deref,
     str::FromStr,
-    sync::{Arc, Mutex, RwLock},
+    sync::{Arc, Mutex},
     vec::Vec,
 };
 use tokio::{runtime::Runtime, task::JoinHandle};
 
 use crate::internal::ObserverWorkerThreadData;
-use exch_clients::BinanceClient;
 use exch_observer_types::{
     AskBidValues, ExchangeObserver, ExchangeValues, OrderedExchangeSymbol, PairedExchangeSymbol,
     SwapOrder, USD_STABLES,
@@ -111,8 +110,6 @@ where
     /// map from already concatenated pair names, when turning concatenated string into
     /// ExchangeSymbol is impossible.
     price_table: Arc<HashMap<String, Arc<Mutex<AskBidValues>>>>,
-    #[allow(dead_code)]
-    client: Option<Arc<RwLock<BinanceClient<Symbol>>>>,
     async_runner: Arc<Runtime>,
 
     /// Necessary for getting control of the threads execution from a function.
@@ -144,15 +141,11 @@ where
         + PairedExchangeSymbol
         + 'static,
 {
-    pub fn new(
-        client: Option<Arc<RwLock<BinanceClient<Symbol>>>>,
-        async_runner: Arc<Runtime>,
-    ) -> Self {
+    pub fn new(async_runner: Arc<Runtime>) -> Self {
         Self {
             watching_symbols: vec![],
             connected_symbols: HashMap::new(),
             price_table: Arc::new(HashMap::new()),
-            client: client,
             async_runner: async_runner,
 
             threads_data_mapping: HashMap::new(),

--- a/exch_subobservers/src/huobi_obs.rs
+++ b/exch_subobservers/src/huobi_obs.rs
@@ -43,7 +43,6 @@ where
     pub watching_symbols: Vec<Symbol>,
     pub connected_symbols: HashMap<String, Vec<OrderedExchangeSymbol<Symbol>>>,
     price_table: Arc<HashMap<String, Arc<Mutex<AskBidValues>>>>,
-    // client: Option<Arc<RwLock<BinanceClient<Symbol>>>>,
     async_runner: Arc<Runtime>,
 
     /// Necessary for getting control of the threads execution from a function.
@@ -79,7 +78,6 @@ where
             watching_symbols: vec![],
             connected_symbols: HashMap::new(),
             price_table: Arc::new(HashMap::new()),
-            // client: client,
             async_runner: async_runner,
 
             threads_data_mapping: HashMap::new(),

--- a/exch_subobservers/src/kraken_obs.rs
+++ b/exch_subobservers/src/kraken_obs.rs
@@ -35,7 +35,6 @@ where
     pub watching_symbols: Vec<Symbol>,
     pub connected_symbols: HashMap<String, Vec<OrderedExchangeSymbol<Symbol>>>,
     price_table: Arc<HashMap<String, Arc<Mutex<AskBidValues>>>>,
-    // client: Option<Arc<RwLock<BinanceClient<Symbol>>>>,
     async_runner: Arc<Runtime>,
 
     /// Necessary for getting control of the threads execution from a function.
@@ -71,7 +70,6 @@ where
             watching_symbols: vec![],
             connected_symbols: HashMap::new(),
             price_table: Arc::new(HashMap::new()),
-            // client: client,
             async_runner: async_runner,
 
             threads_data_mapping: HashMap::new(),


### PR DESCRIPTION
This change was due to awkwardness of merging clients and observers together and requirement of private keys on some of clients.